### PR TITLE
Adds template for single day schedules

### DIFF
--- a/main.py
+++ b/main.py
@@ -196,18 +196,14 @@ def schedule():
     # Hacky hardcoding of days
     data["thu"] = {
         "speakers": [x for x in site_data['speakers'] if x['day'] == 'thu'],
+        "schedule": site_data['daytoview']['thursday'],
         "highlighted": [
             format_paper(by_uid["papers"][h["UID"]]) for h in site_data["highlighted"]
         ],
     }
     data["fri"] = {
         "speakers": [x for x in site_data['speakers'] if x['day'] == 'fri'],
-        "highlighted": [
-            format_paper(by_uid["papers"][h["UID"]]) for h in site_data["highlighted"]
-        ],
-    }
-    data["sat"] = {
-        "speakers": [x for x in site_data['speakers'] if x['day'] == 'sat'],
+        "schedule": site_data['daytoview']['friday'],
         "highlighted": [
             format_paper(by_uid["papers"][h["UID"]]) for h in site_data["highlighted"]
         ],

--- a/sitedata/daytoview.yml
+++ b/sitedata/daytoview.yml
@@ -1,0 +1,30 @@
+thursday:
+  - time: Coming soon
+    type: Coming soon
+    title: Coming soon
+    speaker: Coming soon
+    moderator: Coming soon
+    doclink: Coming soon
+    videolink: Coming soon
+  - time: Coming soon
+    type: Coming soon
+    title: Coming soon
+    speaker: Coming soon
+    moderator: Coming soon
+    doclink: Coming soon
+    videolink: Coming soon
+friday:
+  - time: Coming soon
+    type: Coming soon
+    title: Coming soon
+    speaker: Coming soon
+    moderator: Coming soon
+    doclink: Coming soon
+    videolink: Coming soon
+  - time: Coming soon
+    type: Coming soon
+    title: Coming soon
+    speaker: Coming soon
+    moderator: Coming soon
+    doclink: Coming soon
+    videolink: Coming soon

--- a/templates/components.html
+++ b/templates/components.html
@@ -260,3 +260,34 @@
 {% endfor %}
 {%- endmacro %}
 
+{% macro day_to_view(day) -%}
+<div class="cards row">
+  <table class="table table-striped">
+  <thead>
+    <tr>
+      <th scope="col">Time</th>
+      <th scope="col">Type</th>
+      <th scope="col">Title</th>
+      <th scope="col">Speaker</th>
+      <th scope="col">Moderator</th>
+      <th scope="col">Read more</th>
+      <th scope="col">Video link</th>
+    </tr>
+  </thead>
+    <tbody>
+    {% for row in day %}
+    <tr>
+      <td>{% if row.time %}{{ row.time }}{% endif %}</td>
+      <td>{% if row.type %}{{ row.type }}{% endif %}</td>
+      <td>{% if row.title %}{{ row.title }}{% endif %}</td>
+      <td>{% if row.speaker %}{{ row.speaker }}{% endif %}</td>
+      <td>{% if row.moderator %}{{ row.moderator }}{% endif %}</td>
+      <td>{% if row.doclink %}{{ row.doclink }}{% endif %}</td>
+      <td>{% if row.videolink %}{{ row.videolink }}{% endif %}</td>
+    </tr>
+{% endfor %}
+  </tbody>
+</table>
+</div>
+{%- endmacro %}
+

--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -71,14 +71,13 @@
   >
     <div id="thu">
       <!-- Speakers -->
-      {{ components.section("Keynote speakers") }}
+      {{ components.section("Thursday") }}
+
       <div class="speakers">
-        {{ components.speakergroup(thu.speakers) }}
+        {{ components.day_to_view(thu.schedule) }}
       </div>
       {{ components.section("Highlighted Papers") }}
-      <div class="papers">
-        {{ components.highlightgroup(thu.highlighted, 1) }}
-      </div>
+      {{ components.highlightgroup(thu.highlighted, 1) }}
     </div>
 
     <script type="text/javascript">
@@ -95,14 +94,13 @@
   >
     <div id="fri">
       <!-- Speakers -->
-      {{ components.section("Keynote speakers") }}
+      {{ components.section("Friday") }}
+
       <div class="speakers">
-        {{ components.speakergroup(fri.speakers) }}
+        {{ components.day_to_view(fri.schedule) }}
       </div>
       {{ components.section("Highlighted Papers") }}
-      <div class="papers">
-        {{ components.highlightgroup(fri.highlighted, 1) }}
-      </div>
+      {{ components.highlightgroup(fri.highlighted, 1) }}
     </div>
 
     <script type="text/javascript">


### PR DESCRIPTION
This pull request adds functionality for single day schedules, as requested in #17. The programme details will need to be added to the sitedata/daytoview.yml file (https://github.com/acm-chil/acm-chil-website/compare/master...acm-chil:days?expand=1#diff-a746c61c28f7040566241c5128c4a8b6)

![Screen Shot 2020-07-08 at 10 19 53](https://user-images.githubusercontent.com/822601/86930079-927e4480-c104-11ea-98d5-26d49326b56f.png)
