### PR TITLE
remove calendar. ref #22

### DIFF
--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -7,8 +7,7 @@
 {% endblock %}
 
 {% block tabs %}
-{{ components.tabs([("calendar", "Calendar", "active"),
-                    ("thu", "Thursday", ""),
+{{ components.tabs([("thu", "Thursday", "active"),
                     ("fri", "Friday", ""),
                     ("preview", "Recommended Viewing", ""),
                     ("keynote", "Keynotes", ""),
@@ -18,29 +17,6 @@
 
 {% block content %}
 <div class="tab-content py-3 px-3 px-sm-0" id="nav-tabContent">
-  <!-- Calender tab -->
-  <div
-    class="tab-pane active"
-    id="tab-calendar"
-    role="tabpanel"
-    aria-labelledby="nav-profile-tab"
-  >
-    <div class="form-group col">
-      <label for="tzOptions">Timezone:</label>
-      <select id="tzOptions" class="selectpicker" data-live-search="true">
-      </select>
-    </div>
-
-    <!-- full cal for browser-->
-    <div id="calendar" class="d-none d-sm-block"></div>
-
-    <!-- small cal for smart phones-->
-    <div id="calendar_small" class="d-sm-none"></div>
-
-    <script type="text/javascript">
-      make_cal("serve_main_calendar.json");
-    </script>
-  </div>
 
   <!-- Keynote Tab -->
   <div
@@ -64,7 +40,7 @@
 
   <!-- Thursday Tab -->
   <div
-    class="tab-pane fade"
+    class="tab-pane active"
     id="tab-thu"
     role="tabpanel"
     aria-labelledby="nav-profile-tab"


### PR DESCRIPTION
Removes the calendar page, and instead defaults to the schedule for Thursday. Follows discussion in #22.

The calendar doesn't add anything at the moment, and adds to overhead in keeping the site updated.