### PR TITLE
Add tutorial authors to "daytoview"

### DIFF
--- a/sitedata/daytoview.yml
+++ b/sitedata/daytoview.yml
@@ -20,7 +20,7 @@ thursday:
   - time: "10:00 AM - 10:50 AM" 
     type: Tutorial 
     title: "Public Health Datasets for Deep Learning: Challenges and Opportunities "
-    speaker: Ziad Obermeyer, Katy Haynes, Josh Risley 
+    speaker: Ziad Obermeyer, Katy Haynes, Amy Pitelka, Josh Risley, Katie Lin
     moderator: Tom Pollard, Irene Chen 
     doclink: "https://www.chilconference.org/tutorial_c.html"
     sessionlink: https://acm-org.zoom.us/j/92252417545


### PR DESCRIPTION
Adds two tutorial authors (Amy Pitelka and Katie Li) to the "daytoview", Follows the comment at: https://github.com/acm-chil/acm-chil-website/pull/57#issuecomment-662031951