### PR TITLE
manually populate CFP and schedule with summarised data from 2020

### DIFF
--- a/templates/call-for-papers.html
+++ b/templates/call-for-papers.html
@@ -12,7 +12,7 @@
 <div class="page-header text-center">
   <h1>Call for Papers</h1>
 </div>
-<div class="page-content text-center">
+<div class="page-content">
   {{ call_for_papers | markdown }}
 </div>
 {% endblock %}

--- a/templates/content/call-for-papers.md
+++ b/templates/content/call-for-papers.md
@@ -1,1 +1,62 @@
-Coming soon.
+Call for papers coming soon!
+
+
+## CHIL 2020 CFP (abridged)
+
+The ACM Conference on Health, Inference, and Learning (CHIL) solicits work across a variety of disciplines, including machine learning, statistics, epidemiology, health policy, operations, and economics. CHIL 2020 invites submissions touching on topics focused on relevant problems affecting health. Specifically, authors are invited to submit 8-10 page papers (with unlimited pages for references) to each of the tracks described below.
+
+To ensure that all submissions to CHIL are reviewed by a knowledgeable and appropriate set of reviewers, the conference is divided into tracks and areas of interest. Authors will select exactly one primary track and area of interest when they register their submissions, in addition to one or more sub-disciplines.
+
+Track chairs will oversee the reviewing process. In case you are not sure which track your submission fits under, feel free to contact the track or PC chairs for clarification. The PC Chairs reserve the right to move submissions between tracks and/or areas of interest if the PC believes that a submission has been misclassified.
+
+
+#### Important dates
+
+_Note that although CHIL 2020 was held in July, the CFP timelines targeted an initial conference date in early April. The conference was delayed by the COVID-19 pandemic, but the proceedings were not._
+
+- Submissions due – January 13, 2020 (11:59 pm AoE)
+- Notification of Acceptance – Feb 12, 2020 (11:59 pm AoE)
+- Camera Ready Due – March 6, 2020 (11:59 pm AoE)
+- (Original) Conference Date – April 2-4, 2020
+
+#### Tracks
+
+- Track 1: Machine Learning: Models, Algorithms, Inference, and Estimation
+- Track 2: Applications: Investigation, Evaluation, and Interpretation
+- Track 3: Policy: Impact, Economics, and Society
+- Track 4: Practice: Deployments, Systems, and Datasets
+
+**Track 1: Machine Learning: Models, Algorithms, Inference, and Estimation**
+
+Advances in machine learning are critical for a better understanding of health. This track seeks contributions in modeling, inference, and estimation in health-focused or health-inspired settings. We welcome submissions that develop novel methods and algorithms, introduce relevant machine learning tasks, or identify challenges with prevalent approaches. Submissions focused more on health applications, for example establishing baselines or suggesting new evaluation metrics for assessing algorithmic advances are encouraged to submit to Track 2 instead.
+
+While submissions should address problems relevant to health, the contributions themselves are not required to be directly applied to health. For example, authors may use synthetic datasets and experiments to demonstrate the properties of algorithms.
+
+Authors may consider one or more machine learning sub-discipline(s) from the following non-exhaustive list: Bayesian learning, Causal inference, Computer vision, Deep learning architectures Evaluation methods, Inference, Knowledge graphs, Natural language processing, Reinforcement Learning, Representation learning, Robust learning, Structured learning, Supervised learning, Survival analysis, Time series, Transfer learning, Unsupervised learning, Explainability, Algorithmic Fairness.
+
+
+**Track 2: Applications: Investigation, Evaluation, and Interpretation**
+
+The goal of this track is to highlight works applying robust methods, models, or practices to identify, characterize, audit, evaluate, or benchmark systems. Whereas the goal of Track 1 is to select papers that show significant technical novelty, submit your work here if the contribution is more focused on solving a carefully motivated problem grounded in applications. Introducing a new method is not prohibited by any means for this track, but the focus should be on methods which are designed to work particularly robustly (e.g., fail gracefully in practice), scale particularly well either in terms of computational runtime or data required, work across real-world data modalities and systems, etc. Contributions will be evaluated for technical rigor, robustness, and comprehensiveness.
+
+**Track 3: Policy: Impact, Economics, and Society**
+
+Algorithms do not exist in the digital world alone: indeed, they often explicitly take aim at important social outcomes. This track considers issues at the intersection of algorithms and the societies they seek to impact. This track welcomes theoretical, methodological, and applied contributions for understanding and accounting for fairness, accountability, and transparency of algorithmic systems and for societal applications including mitigating discrimination, inequality, public health, health systems, policy applications, and other societal impacts from the deployment of such systems in real-world contexts. Given the societal implications of this area of focus, it includes work using data that fall out of traditional clinical data streams and includes health and non-health data sources including demographic data, online data streams, environmental and climate data. This includes the development of machine learning methods relevant to policy and public health, or new methods for working with data related for broader societal applications.
+
+We welcome papers from various sub-disciplines (see list below). Paper submissions must indicate at least one area of interest (see list below) and at least one sub-discipline upon abstract registration.
+
+Methods for combining non-clinical and clinical data; Understanding includes detecting and measuring how and which forms of bias are manifested in datasets and models; determining how algorithmic systems may introduce, exacerbate, or reduce inequities, discrimination and unjust outcomes; measuring the efficacy of existing techniques for explaining and interpreting automated decisions; evaluating perceptions of fairness and algorithmic bias. Accounting includes the governance of the design, development and deployment of algorithmic systems, which takes into consideration all stakeholders and interactions with socio-technical systems. Development of multi-level machine learning models (e.g. combining individual and population-level information); Mitigating includes introducing techniques for data collection and analysis and processing that measure, incorporate and acknowledge the selection bias and discrimination that may be present in datasets and models; formalizing fairness objectives based on notions from the social sciences, law, and humanistic studies; building socio-technical systems which incorporate these insights to minimize harm on historically disadvantaged communities and empower them; introducing methods for decision validation, correction and participation in co-designing algorithmic systems. Methods for generating spatial or temporal features relevant to health from noisy point observations.
+
+**Track 4: Practice: Deployments, Systems, and Datasets**
+
+The transformation of healthcare through computational approaches is dependent on understanding how to empirically evaluate these systems, widely sharing tools for conducting research, and publicly accessible data allowing fair comparison of methods. This track seeks descriptions of the implementation or evaluation of informatics-based studies, computer software which has direct utility for medical researchers, and new datasets which support healthcare research.
+
+Informatics based studies should primarily focus on evaluating these systems in clinical practice. Examples include applications of predictive modeling, deployment of a clinical decision support system, or evaluation of the impact of digital user interface modifications on routine practice.
+
+Computer software submissions should describe the intended use for the software, justify the need for the software, and provide executable examples for other researchers. Software submissions should directly support a healthcare application. Examples include code for summarizing the demographics of a study cohort, deriving meaningful clinical concepts from electronic health records, and natural language processing tools specifically designed for clinical text. All computer software submissions must be open source and released under a suitable open source license. Computer software should adhere to best practices in software development where possible, including the use of unit tests, continuous integration, and diligent documentation of component design and purpose.
+
+Descriptions of databases to support biomedical or health research are welcome. Dataset publications should focus on helping others reuse the data, rather than demonstrating any new insights or techniques. Datasets should include a full detailed description including the methods used to collect the data, the structure of records in the data, technical analyses supporting the quality of the data, and executable code demonstrating the use of the data. In terms of scope, we welcome datasets both large and small, so long as there is potential for a direct healthcare application. Datasets should be publicly available in an appropriate data repository with reasonable mechanisms for providing external researchers with access. Examples of suitable data repositories include but are not limited to Dryad, FigShare, PhysioNet, Synapse, or a university established data repository.
+
+#### Open Access
+
+ACM CHIL is committed to open science and ensuring our proceedings are freely available. The conference will make use of the ‘ACM Authorizer “Open Access” Service’ and ‘ACM OpenTOC Service’, allowing unrestricted access to individual papers as well as the overall proceedings, [see here](https://www.acm.org/publications/openaccess) for more details.

--- a/templates/content/schedule.md
+++ b/templates/content/schedule.md
@@ -1,1 +1,21 @@
-Conference program coming soon.
+Conference program coming soon!
+
+## Highlights from CHIL 2020
+
+CHIL 2020 was held virtually on July 23rd and 24th. It featured 23 research talks from accepted papers, 23 workshop spotlights, and 15 participants in the doctoral symposium.
+
+### Keynotes
+
+- Yoshua Bengio - _Machine Learning Challenges in the Fight for Social Good - the Covid-19 Case_
+- Elaine Nsoesie - _Digital Platforms & Public Health in Africa_
+- Sherri Rose - _Machine Learning in Health Care: Too Important to Be a Toy Example_
+- Ruslan Salakhutdinov - _Incorporating Domain Knowledge into Deep Learning Models_
+- Nigam Shah - _A framework for shaping the future of AI in healthcare_
+
+### Tutorials
+
+- A Tour of Survival Analysis, from Classical to Modern - George H. Chen, Jeremy C. Weiss
+- Population and public health: challenges and opportunities  - Vishwali Mhasawade, Yuan Zhao, Rumi Chunara
+- Public Health Datasets for Deep Learning: Challenges and Opportunities  - Ziad Obermeyer, Katy Haynes, Amy Pitelka, Josh Risley, Katie Lin
+- State of the Art Deep Learning in Medical Imaging  - Joseph Paul Cohen
+- Analyzing critical care data, from speculation to publication, starring MIMIC-IV - Alistair Johnson

--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -18,7 +18,7 @@
 <div class="page-header text-center">
   <h1>Schedule</h1>
 </div>
-<div class="page-content text-center">
+<div class="page-content">
   {{ schedule | markdown }}
 </div>
 


### PR DESCRIPTION
Proposal for (temporary) content for Schedule and CFP pages, featuring 2020 content, while we work out proper archiving strategy.